### PR TITLE
hotfix albumView에서 cameraView로 이동하는 방식 변경

### DIFF
--- a/Popin/Sources/Screens/Album/AlbumViewController.swift
+++ b/Popin/Sources/Screens/Album/AlbumViewController.swift
@@ -8,6 +8,7 @@ import CoreLocation
 import MapKit
 import SnapKit
 import Kingfisher
+import Photos
 
 class CustomImageAnnotation: NSObject, MKAnnotation {
     let coordinate: CLLocationCoordinate2D
@@ -254,10 +255,18 @@ class AlbumViewController: BaseViewController, CLLocationManagerDelegate, AlbumH
         navigationController?.popViewController(animated: true)
     }
     
+    private func cameraAuth() {
+        AVCaptureDevice.requestAccess(for: .video) { granted in
+            if granted {
+                print("권한 허용")
+            } else {
+                print("권한 거부")
+            }
+        }
+    }
+    
     func plusButtonTapped() {
-        let cameraViewController = CameraViewController()
-        cameraViewController.initialLocation = initialLocation
-        navigationController?.pushViewController(cameraViewController, animated: true)
+        cameraAuth()
     }
     
     func setupStatusBarView() {


### PR DESCRIPTION
- 기존에는 사진 정보 없이 게시물 추가/수정이 가능했으나, 기획 의도 변경으로 기존 화면 이동 방식에 사진 정보 없이 이동하면 생기는 에러 수정
- '+' 버튼이 갤러리에서 사진 선택 & 사진 촬영중 어떤 방식을 채택할지 논의가 필요함 